### PR TITLE
fix syntax error for string comparison

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -78,7 +78,7 @@ build_dir=./build
 rm -rf ${build_dir}
 
 if ($mpi_enabled); then
-    if [[ ${mpi_dir} -eq "" ]]; then
+    if [[ ${mpi_dir} == "" ]]; then
         echo "MPI flag enabled but path to MPI installation not specified.  See --mpi_home command line argument."
         exit 1
     else


### PR DESCRIPTION
Seen a syntax error when passing in the --mpi_home option. 
```
pak@ops001:~/rccl-tests$ ./installer.sh -m --mpi_home=/home/pak/ompi
./install.sh: line 81: [[: /home/pak/ompi: syntax error: operand expected (error token is "/home/pak/ompi")
make -C src build
...
```