### PR TITLE
Disabling host and fine memory types for CI testing

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -27,7 +27,7 @@ def runTestCommand (platform, project)
     def command = """#!/usr/bin/env bash
                 set -x
                 cd ${project.paths.project_build_prefix}
-		python3 -m pytest -k "not MPI" --verbose --junitxml=./testreport.xml
+		python3 -m pytest -k "not MPI and not host and not fine" --verbose --junitxml=./testreport.xml
             """
 
    platform.runCommand(this, command)


### PR DESCRIPTION
This will cut down on the total number of memory allocations, hopefully leading to no more failures as a result of allocating memory too often in rapid succession.