### PR TITLE
update pytest before running CI

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -27,6 +27,8 @@ def runTestCommand (platform, project)
     def command = """#!/usr/bin/env bash
                 set -x
                 cd ${project.paths.project_build_prefix}
+		python3 -m pip install --upgrade pytest
+		python3 -m pytest --version
 		python3 -m pytest -k "not MPI and not host and not fine" --verbose --junitxml=./testreport.xml
             """
 


### PR DESCRIPTION
There seems to be in an incompatibility between the python installation
used in the CI and pytest. Update pytest before running CI.