### PR TITLE
Adding -pthread flag for linking issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 # ########################################################################
 # Copyright 2022 Advanced Micro Devices, Inc.
 # ########################################################################
+#Adding pthread flag for linking
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ HIPCUFLAGS += -I$(ROCM_PATH)/include
 HIPCUFLAGS += -I$(ROCM_PATH)/include/rccl
 HIPCUFLAGS += -I$(ROCM_PATH)/hip/include/hip
 LDFLAGS    += -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt
-HIPLDFLAGS += $(CUSTOM_RCCL_LIB) -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt
+HIPLDFLAGS += $(CUSTOM_RCCL_LIB) -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt -pthread
 
 ifeq ($(DEBUG), 0)
 HIPCUFLAGS += -O3


### PR DESCRIPTION
Adding -pthread flag for linking issues in the rccl-tests master branch into CMakeLists.txt and src/Makefile