### PR TITLE
fix stack-buffer-overflow reported by address sanitizer

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -102,7 +102,7 @@ static double parsesize(const char *value) {
     double size;
     char size_lit;
 
-    int count = sscanf(value, "%lf %1s", &size, &size_lit);
+    int count = sscanf(value, "%lf %c", &size, &size_lit);
 
     switch (count) {
     case 2:


### PR DESCRIPTION
Since ASAN aborts on the first failure found, we need this fix so we can move on to other ASAN reports.