### PR TITLE
BUILD: Modified HIPCC path in src/Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ VERBOSE ?= 0
 DEBUG ?= 0
 NCCL_HOME ?= ""
 
-HIPCC = $(ROCM_PATH)/hip/bin/hipcc
+HIPCC = $(ROCM_PATH)/bin/hipcc
 CXX = $(HIPCC)
 
 HIPCUFLAGS := -std=c++14


### PR DESCRIPTION
Updated HIPCC path for new ROCm directory structure from `$(ROCM_PATH)/hip/bin/hipcc` to `$(ROCM_PATH)/bin/hipcc.