### PR TITLE
Offload arch linking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,9 +6,9 @@
 set_property(SOURCE common.cu timer.cc ../verifiable/verifiable.cu PROPERTY LANGUAGE CXX)
 add_library(rccl_common OBJECT common.cu timer.cc ../verifiable/verifiable.cu)
 if(USE_MPI)
-    target_link_libraries(rccl_common roc::rccl MPI::MPI_CXX)
+    target_link_libraries(rccl_common roc::rccl MPI::MPI_CXX hip::device)
 else()
-    target_link_libraries(rccl_common roc::rccl)
+    target_link_libraries(rccl_common roc::rccl hip::device)
 endif()
 
 function(add_relative_test test_name test_target)
@@ -37,7 +37,6 @@ function(add_rccl_test TEST)
         ${TEST_TARGET}
         PRIVATE
             rccl_common
-            hip::device
     )
     if (NOT WIN32)
         foreach(amdgpu_target ${AMDGPU_TARGETS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ function(add_rccl_test TEST)
         ${TEST_TARGET}
         PRIVATE
             rccl_common
+            hip::device
     )
     if (NOT WIN32)
         foreach(amdgpu_target ${AMDGPU_TARGETS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,9 @@
 # Compile common object library
 set_property(SOURCE common.cu timer.cc ../verifiable/verifiable.cu PROPERTY LANGUAGE CXX)
 add_library(rccl_common OBJECT common.cu timer.cc ../verifiable/verifiable.cu)
+target_link_libraries(rccl_common roc::rccl hip::device)
 if(USE_MPI)
-    target_link_libraries(rccl_common roc::rccl MPI::MPI_CXX hip::device)
-else()
-    target_link_libraries(rccl_common roc::rccl hip::device)
+    target_link_libraries(rccl_common MPI::MPI_CXX)
 endif()
 
 function(add_relative_test test_name test_target)
@@ -38,11 +37,6 @@ function(add_rccl_test TEST)
         PRIVATE
             rccl_common
     )
-    if (NOT WIN32)
-        foreach(amdgpu_target ${AMDGPU_TARGETS})
-            target_link_libraries(${TEST_TARGET} PRIVATE --amdgpu-target=${amdgpu_target})
-        endforeach()
-    endif()
     set_target_properties(
         ${TEST_TARGET}
         PROPERTIES


### PR DESCRIPTION
Previously the tests were compiled with `--amdgpu-target` to compile for multiple architectures, As rccl_common was not compiled against those architectures, this didn't work. Linking it against hip::device automatically links against all architectures in `AMDGPU_TARGETS`, and so are the test executables.

This fix makes rccl-tests respect the `AMDGPU_TARGETS` variable as the rest of ROCm does.