### PR TITLE
Add option to disable out-of-place runs

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -127,6 +127,7 @@ struct threadArgs {
   int localRank;
   int localNumDevices;
   int enable_multiranks;
+  int enable_out_of_place;
   int nRanks;
   void** sendbuffs;
   size_t sendBytes;


### PR DESCRIPTION
This PR adds an option `-O` in rccl tests to disable out-of-place runs. RCCL test should be run with `-O 0` if the user is interested in the in-place outputs only.