### PR TITLE
Amend use of CUSTOM_RCCL_LIB to avoid build error

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -26,7 +26,7 @@ endif
 HIPCUFLAGS += -I$(ROCM_PATH)/include
 HIPCUFLAGS += -I$(ROCM_PATH)/include/hip
 LDFLAGS    += -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt
-HIPLDFLAGS += $(CUSTOM_RCCL_LIB) -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt -pthread
+HIPLDFLAGS += -L$(CUSTOM_RCCL_LIB) -L$(ROCM_PATH)/lib -lhsa-runtime64 -lrt -pthread
 
 ifeq ($(DEBUG), 0)
 HIPCUFLAGS += -O3


### PR DESCRIPTION
Add `-L` to `${CUSTOM_RCCL_LIB}` to avoid build errors when building using Makefile or install script.