### PR TITLE
Scaling tests to #ngpus

### DIFF
--- a/test/test_AllGather.py
+++ b/test/test_AllGather.py
@@ -22,12 +22,22 @@
 import os
 import subprocess
 import itertools
+import math
 
 import pytest
 
+ngpus = 0
+if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['ROCR_VISIBLE_DEVICES'].split(","))
+elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
+else:
+    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+log_ngpus = int(math.log2(ngpus))
+
 nthreads = ["1"]
 nprocs = ["2"]
-ngpus_single = ["1","2","4"]
+ngpus_single = [str(2**x) for x in range(log_ngpus+1)]
 ngpus_mpi = ["1","2"]
 byte_range = [("4", "128M")]
 op = ["sum", "prod", "min", "max"]

--- a/test/test_AllGather.py
+++ b/test/test_AllGather.py
@@ -32,7 +32,7 @@ if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
 elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
     ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
 else:
-    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+    ngpus = int(subprocess.check_output("rocminfo | grep \"Device Type:.\s*.GPU\" | wc -l",shell=True))
 log_ngpus = int(math.log2(ngpus))
 
 nthreads = ["1"]

--- a/test/test_AllReduce.py
+++ b/test/test_AllReduce.py
@@ -22,12 +22,22 @@
 import os
 import subprocess
 import itertools
+import math
 
 import pytest
 
+ngpus = 0
+if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['ROCR_VISIBLE_DEVICES'].split(","))
+elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
+else:
+    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+log_ngpus = int(math.log2(ngpus))
+
 nthreads = ["1"]
 nprocs = ["2"]
-ngpus_single = ["1","2","4"]
+ngpus_single = [str(2**x) for x in range(log_ngpus+1)]
 ngpus_mpi = ["1","2"]
 byte_range = [("4", "128M")]
 op = ["sum", "prod", "min", "max"]

--- a/test/test_AllReduce.py
+++ b/test/test_AllReduce.py
@@ -32,7 +32,7 @@ if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
 elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
     ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
 else:
-    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+    ngpus = int(subprocess.check_output("rocminfo | grep \"Device Type:.\s*.GPU\" | wc -l",shell=True))
 log_ngpus = int(math.log2(ngpus))
 
 nthreads = ["1"]

--- a/test/test_Broadcast.py
+++ b/test/test_Broadcast.py
@@ -22,12 +22,22 @@
 import os
 import subprocess
 import itertools
+import math
 
 import pytest
 
+ngpus = 0
+if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['ROCR_VISIBLE_DEVICES'].split(","))
+elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
+else:
+    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+log_ngpus = int(math.log2(ngpus))
+
 nthreads = ["1"]
 nprocs = ["2"]
-ngpus_single = ["1","2","4"]
+ngpus_single = [str(2**x) for x in range(log_ngpus+1)]
 ngpus_mpi = ["1","2"]
 byte_range = [("4", "128M")]
 op = ["sum", "prod", "min", "max"]

--- a/test/test_Broadcast.py
+++ b/test/test_Broadcast.py
@@ -32,7 +32,7 @@ if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
 elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
     ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
 else:
-    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+    ngpus = int(subprocess.check_output("rocminfo | grep \"Device Type:.\s*.GPU\" | wc -l",shell=True))
 log_ngpus = int(math.log2(ngpus))
 
 nthreads = ["1"]

--- a/test/test_Reduce.py
+++ b/test/test_Reduce.py
@@ -22,12 +22,22 @@
 import os
 import subprocess
 import itertools
+import math
 
 import pytest
 
+ngpus = 0
+if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['ROCR_VISIBLE_DEVICES'].split(","))
+elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
+else:
+    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+log_ngpus = int(math.log2(ngpus))
+
 nthreads = ["1"]
 nprocs = ["2"]
-ngpus_single = ["1","2","4"]
+ngpus_single = [str(2**x) for x in range(log_ngpus+1)]
 ngpus_mpi = ["1","2"]
 byte_range = [("4", "128M")]
 op = ["sum", "prod", "min", "max"]

--- a/test/test_Reduce.py
+++ b/test/test_Reduce.py
@@ -32,7 +32,7 @@ if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
 elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
     ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
 else:
-    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+    ngpus = int(subprocess.check_output("rocminfo | grep \"Device Type:.\s*.GPU\" | wc -l",shell=True))
 log_ngpus = int(math.log2(ngpus))
 
 nthreads = ["1"]

--- a/test/test_ReduceScatter.py
+++ b/test/test_ReduceScatter.py
@@ -22,12 +22,22 @@
 import os
 import subprocess
 import itertools
+import math
 
 import pytest
 
+ngpus = 0
+if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['ROCR_VISIBLE_DEVICES'].split(","))
+elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
+    ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
+else:
+    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+log_ngpus = int(math.log2(ngpus))
+
 nthreads = ["1"]
 nprocs = ["2"]
-ngpus_single = ["1","2","4"]
+ngpus_single = [str(2**x) for x in range(log_ngpus+1)]
 ngpus_mpi = ["1","2"]
 byte_range = [("4", "128M")]
 op = ["sum", "prod", "min", "max"]

--- a/test/test_ReduceScatter.py
+++ b/test/test_ReduceScatter.py
@@ -32,7 +32,7 @@ if os.environ.get('ROCR_VISIBLE_DEVICES') is not None:
 elif os.environ.get('HIP_VISIBLE_DEVICES') is not None:
     ngpus = len(os.environ['HIP_VISIBLE_DEVICES'].split(","))
 else:
-    ngpus = int(subprocess.check_output("rocm-smi --showhw | wc -l",shell=True)) - 7
+    ngpus = int(subprocess.check_output("rocminfo | grep \"Device Type:.\s*.GPU\" | wc -l",shell=True))
 log_ngpus = int(math.log2(ngpus))
 
 nthreads = ["1"]


### PR DESCRIPTION
Currently number of devices for tests are hard-coded to 1, 2, 4, sometimes it fails on nodes with less than 4 GPUs, or won't run up to all devices when nodes have more than 4