### PR TITLE
Fixing make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,7 @@ default: src.build
 
 TARGETS=$(filter-out src/hypercube.cu, $(wildcard src/*))
 
-all:   ${TARGETS:%=%.build}
-clean: ${TARGETS:%=%.clean}
+clean: src.clean
 
 %.build:
 	${MAKE} -C $* build BUILDDIR=${BUILDDIR}


### PR DESCRIPTION
`make clean` has been broken for a while. In general I think `all` and `clean` wouldn't work correctly, so added default `clean` = `src.clean` 