### PR TITLE
Fix --root all issue

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -1019,7 +1019,7 @@ int main(int argc, char* argv[]) {
         nccltype = ncclstringtotype(optarg);
         break;
       case 'r':
-        ncclroot = strtol(optarg, NULL, 0);
+        ncclroot = ncclstringtoroot(optarg);
         break;
       case 'z':
         blocking_coll = strtol(optarg, NULL, 0);
@@ -1099,7 +1099,7 @@ int main(int argc, char* argv[]) {
             "[-o,--op <sum/prod/min/max/all>] \n\t"
 #endif
             "[-d,--datatype <nccltype/all>] \n\t"
-            "[-r,--root <root>] \n\t"
+            "[-r,--root <root/all>] \n\t"
             "[-z,--blocking <0/1>] \n\t"
             "[-Y,--memory_type <coarse/fine/host/managed>] \n\t"
             "[-s,--stress_cycles <number of cycles>] \n\t"

--- a/src/common.h
+++ b/src/common.h
@@ -294,6 +294,13 @@ static int ncclstringtoop (char *str) {
     return ncclSum;
 }
 
+static int ncclstringtoroot (char *str) {
+    if (strcmp(str, "all") == 0) {
+      return -1;
+    }
+    return strtol(str, NULL, 0);
+}
+
 static int ncclstringtomtype (char *str) {
     for (int o=0; o<nccl_NUM_MTYPES; o++) {
       if (strcmp(str, test_memorytypes[o]) == 0) {


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Fixed the way --root option is being parsed internally. Currenlty, `--root` doesn't handle "all" option. 

**Why were the changes made?**  
`-root all `option does not work currently. It defaults to root process 0 and doesn't run for other processes in the comm.

**How was the outcome achieved?**  
Added a wrapper function `ncclstringtoroot` to parse the "all" keyword.


