### PR TITLE
Memset to fix inflated performance when GPU is reset

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -904,6 +904,8 @@ testResult_t AllocateBuffs(void **sendbuff, size_t sendBytes, void **recvbuff, s
     CUDACHECK(cudaMalloc(recvbuff, nbytes));
     if (datacheck) CUDACHECK(cudaMalloc(expected, recvBytes));
   }
+  CUDACHECK(hipMemset(*sendbuff, 1, nbytes));
+  if (datacheck) CUDACHECK(cudaMemset(*expected, 1, recvBytes));
   return testSuccess;
 }
 

--- a/src/common.cu
+++ b/src/common.cu
@@ -905,7 +905,7 @@ testResult_t AllocateBuffs(void **sendbuff, size_t sendBytes, void **recvbuff, s
     if (datacheck) CUDACHECK(cudaMalloc(expected, recvBytes));
   }
   CUDACHECK(hipMemset(*sendbuff, 1, nbytes));
-  if (datacheck) CUDACHECK(cudaMemset(*expected, 1, recvBytes));
+  if (datacheck) CUDACHECK(hipMemset(*expected, 1, recvBytes));
   return testSuccess;
 }
 


### PR DESCRIPTION
This PR addresses inflated bus BW values that are reported when the GPU memory is reset. Based on @gilbertlee-amd and confirmed by me 

> the problem is that we only initialize the first section of the subarray.  The "shifted" sections are all using uninitialized memory - whatever the value of the GPU memory was.
> When we do a GPU reset, this means that the value can be 0, which can ARTIFICIALLY inflate performance (because 0s can be send compressed).
