### PR TITLE
removing FP8 product from allReduce test cases

### DIFF
--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -65,6 +65,8 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
+  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op ==ncclProd)
+    return testSuccess;
 
   if ((int)type != -1) {
     type_count = 1;
@@ -88,6 +90,8 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
+      if((i == ncclFp8E4M3 || i == ncclFp8E5M2) && j ==ncclProd)
+        continue;
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }
   }

--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -65,7 +65,7 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
-  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op ==ncclProd)
+  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
     return testSuccess;
 
   if ((int)type != -1) {
@@ -90,7 +90,7 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
-      if((i == ncclFp8E4M3 || i == ncclFp8E5M2) && j ==ncclProd)
+      if((i == ncclFp8E4M3 || i == ncclFp8E5M2) && j == ncclProd)
         continue;
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }


### PR DESCRIPTION
Filtering FP8 with the product operation from all_reduce test cases.

