### PR TITLE
hot fixing ncclMemFree for mscclpp

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -1401,15 +1401,9 @@ testResult_t run() {
 
   // Free off CUDA allocated memory
   for (int i=0; i<nGpus*nThreads; i++) {
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,19,0)
-    if (sendbuffs[i]) NCCLCHECK(ncclMemFree((char*)sendbuffs[i]));
-    if (recvbuffs[i]) NCCLCHECK(ncclMemFree((char*)recvbuffs[i]));
-    if (datacheck) NCCLCHECK(ncclMemFree(expected[i]));
-#else
     if (sendbuffs[i]) CUDACHECK(cudaFree((char*)sendbuffs[i]));
     if (recvbuffs[i]) CUDACHECK(cudaFree((char*)recvbuffs[i]));
     if (datacheck) CUDACHECK(cudaFree(expected[i]));
-#endif
   }
   CUDACHECK(cudaFreeHost(delta));
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,19,0)


### PR DESCRIPTION
There was a discrepancy of allocating memory with regular hip calls but freeing via ncclMemFree, and it's causing issues as mscclpp is integrated into RCCL. I think the most robust solution is to call ncclMemAlloc, but unlike nccl we have variations of hip memory alloc which I'm not sure if they'd be included ncclMemAlloc in or how. Temporarily I'm just eliminating ncclMemFree to get pass this error, will likely come back to it