### PR TITLE
[AllReduce] Enable FP8 conditions only if FP8 is supported

### DIFF
--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -65,8 +65,10 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
+#if defined(RCCL_FLOAT8)
   if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
     return testSuccess;
+#endif
 
   if ((int)type != -1) {
     type_count = 1;
@@ -90,8 +92,10 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
+#if defined(RCCL_FLOAT8)
       if((i == ncclFp8E4M3 || i == ncclFp8E5M2) && j == ncclProd)
         continue;
+#endif
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }
   }


### PR DESCRIPTION
## Details

**Work item:**
https://github.com/ROCm/rccl-tests/issues/103

**What were the changes?**  
Wrap FP8-based conditions in AllReduce (introduced in https://github.com/ROCm/rccl-tests/commit/77ae744c181c02fade85b8b0536b5dba8928c461) to enable logic only if FP8 is supported.

**Why were the changes made?**  
Compilation errors on older ROCm which does not support FP8.
