### PR TITLE
Fix NaN issue in verifiable.cu

### DIFF
--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -671,81 +671,103 @@ __host__ __device__ void genOutput(
 // Nil reduction (byte copy functions). Optimized to assume rank_n=1
 
 namespace {
-template<typename T, bool IsIntegral>
-struct FloatingPointTraits;
+  template<typename T, bool IsIntegral>
+  struct FloatingPointTraits;
+  
+  template<>
+  struct FloatingPointTraits<__half, false> {
+    static constexpr int exponentBits = 5;
+    static constexpr uint64_t exponentMask = 0x7C00; // 0111 1100 0000 0000
+    static constexpr uint64_t normalExponent = 0x0F;
+  };
+  
+  template<>
+  struct FloatingPointTraits<float, false> {
+    static constexpr int exponentBits = 8;
+    static constexpr uint64_t exponentMask = 0x7F800000;
+    static constexpr uint64_t normalExponent = 0x7F;
+  };
+  
+  template<>
+  struct FloatingPointTraits<double, false> {
+    static constexpr int exponentBits = 11;
+    static constexpr uint64_t exponentMask = 0x7FF0000000000000;
+    static constexpr uint64_t normalExponent = 0x3FF;
+  };
+  
+  #if RCCL_BFLOAT16 == 1
+  template<>
+  struct FloatingPointTraits<hip_bfloat16, false> {
+    static constexpr int exponentBits = 8;
+    static constexpr uint64_t exponentMask = 0x7F80;
+    static constexpr uint64_t normalExponent = 0x7F;
+  };
+  #endif
 
-template<>
-struct FloatingPointTraits<__half, false> {
-  static constexpr int exponentBits = 5;
-  static constexpr uint64_t exponentMask = 0x7C00; // 0111 1100 0000 0000
-  static constexpr uint64_t normalExponent = 0x0F;
-};
+  #if RCCL_FLOAT8 == 1
+  template<>
+  struct FloatingPointTraits<rccl_float8, false> {
+    static constexpr int exponentBits = 4; // fp8e4m3 format
+    // FNUZ format defines 0x80 as NaN -> only sign bit set to 1 and rest set to 0
+    #if HIP_FP8_TYPE_FNUZ == 1
+      static constexpr uint64_t exponentMask = 0x80;
+    #else
+      static constexpr uint64_t exponentMask = 0x7F;
+    #endif
+    static constexpr uint64_t normalExponent = 0x07;
+  };
+  
+  template<>
+  struct FloatingPointTraits<rccl_bfloat8, false> {
+    static constexpr int exponentBits = 5; // fp8e5m2 format
+    #if HIP_FP8_TYPE_FNUZ == 1
+      static constexpr uint64_t exponentMask = 0x80;
+    #else
+      static constexpr uint64_t exponentMask = 0x7C;
+    #endif
+    static constexpr uint64_t normalExponent = 0x0F;
+  };
+  #endif
 
-template<>
-struct FloatingPointTraits<float, false> {
-  static constexpr int exponentBits = 8;
-  static constexpr uint64_t exponentMask = 0x7F800000;
-  static constexpr uint64_t normalExponent = 0x7F;
-};
-
-template<>
-struct FloatingPointTraits<double, false> {
-  static constexpr int exponentBits = 11;
-  static constexpr uint64_t exponentMask = 0x7FF0000000000000;
-  static constexpr uint64_t normalExponent = 0x3FF;
-};
-
-template<>
-struct FloatingPointTraits<hip_bfloat16, false> {
-  static constexpr int exponentBits = 8;
-  static constexpr uint64_t exponentMask = 0x7F80;
-  static constexpr uint64_t normalExponent = 0x7F;
-};
-
-template<>
-struct FloatingPointTraits<rccl_float8, false> {
-  static constexpr int exponentBits = 4; // fp8e4m3 format
-  static constexpr uint64_t exponentMask = 0x78;
-  static constexpr uint64_t normalExponent = 0x07;
-};
-
-template<>
-struct FloatingPointTraits<rccl_bfloat8, false> {
-  static constexpr int exponentBits = 5; // fp8e5m2 format
-  static constexpr uint64_t exponentMask = 0xF8;
-  static constexpr uint64_t normalExponent = 0x0F;
-};
-
-template<typename T, bool IsIntegral>
-__host__ __device__ void genInput(
-    T &ans, ReduceNil, int rank_n, int rank_me, uint64_t seed, intptr_t index,
-    std::integral_constant<bool, IsIntegral>
-  ) {
-  (void)rank_n, (void)rank_me; // silence unused warnings
-  union { uint64_t bits; T tmp; };
-  bits = mixBits(seed ^ index);
-  bits >>= 64 - 8*sizeof(T);
-  bits &= uint64_t(-1)>>(64 - 8*sizeof(T));
-
-  if constexpr(!IsIntegral) { // Checks if the datatype is not integral
-    constexpr int exponentBits = FloatingPointTraits<T, IsIntegral>::exponentBits;
-    constexpr uint64_t exponentMask = FloatingPointTraits<T, IsIntegral>::exponentMask;
-    constexpr uint64_t normalExponent = FloatingPointTraits<T, IsIntegral>::normalExponent;
-    if ((bits & exponentMask) == exponentMask) { // Checks if all exponent bits are set to 1, representing NaN or infinity
-      bits &= ~exponentMask; // Clears the exponent bits
-      bits |= normalExponent << (8 * sizeof(T) - exponentBits - 1);  // Set the exponent to a normal value
+  template<typename T, bool IsIntegral>
+  __host__ __device__ void genInput(
+      T &ans, ReduceNil, int rank_n, int rank_me, uint64_t seed, intptr_t index,
+      std::integral_constant<bool, IsIntegral>
+    ) {
+    (void)rank_n, (void)rank_me; // silence unused warnings
+    union { uint64_t bits; T tmp; };
+    bits = mixBits(seed ^ index);
+    bits >>= 64 - 8*sizeof(T);
+    bits &= uint64_t(-1)>>(64 - 8*sizeof(T));
+  
+    if constexpr(!IsIntegral) { // Ensures datatype is not integral
+      constexpr int exponentBits = FloatingPointTraits<T, IsIntegral>::exponentBits;
+      constexpr uint64_t exponentMask = FloatingPointTraits<T, IsIntegral>::exponentMask;
+      constexpr uint64_t normalExponent = FloatingPointTraits<T, IsIntegral>::normalExponent;
+      bool modify_bits = false;
+      // FP8 FNUZ format requires a different check for NaN
+      if constexpr(__hip_internal::is_same<T, rccl_float8>::value || 
+      __hip_internal::is_same<T, rccl_bfloat8>::value) {
+        #if HIP_FP8_TYPE_FNUZ == 1
+          modify_bits = (bits == exponentMask);
+        #endif
+      }
+      // For other float types, it Checks if all exponent bits are set to 1 representing NaN or infinity
+      if (((bits & exponentMask) == exponentMask) || modify_bits) { 
+          bits &= ~exponentMask; // Clears the exponent bits
+          bits |= normalExponent << (8 * sizeof(T) - exponentBits - 1); // Set exponent to 1.0 (normal exp)
+      }
     }
+    ans = tmp;
   }
-  ans = tmp;
-}
 
-template<typename T, typename ReduceFn, bool IsIntegral>
-__host__ __device__ void genOutput(
+  template<typename T, typename ReduceFn, bool IsIntegral>
+  __host__ __device__ void genOutput(
     T &ans, ReduceNil op, int rank_n, uint64_t seed, intptr_t index,
     std::integral_constant<bool, IsIntegral>
-  ) {
-  ans = genInput<T>(op, rank_n, 0, seed, index);
-}
+    ) {
+    ans = genInput<T>(op, rank_n, 0, seed, index);
+  }
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
Internal

**What were the changes?**  
Modified genInput function performing reduceNil operation. Added floating traits for various float datatypes (half, double, bfloat, etc) defining exponentMask and normalexponent values, which allows checking for a NaN number. The generated number is either NaN or infinity if all the exponent bits are set to 1. In the genInput function, we check if the generated number is float and NaN, then modify the bits if NaN is detected.

**Why were the changes made?**  
genInput function (reduceNil) generates NaN values for floating point numbers, impacting most of the collectives. Only reduceNil is impacted by NaN inputs - No issues with other reduction operations. ReduceNil is called by default when rank = 1 and it simply returns the input as output.

**How was the outcome achieved?**  
There is no problem with Integer datatypes. First, we identify whether the datatype is float and all exponent bits are set to 1. If that's the case we clear the exponent bits and set to it a normal exponent value (i.e 1.0). Different checks are required if FP8 uses FNUZ format.

**Additional Documentation:**  
_What else should the reviewer know?_
