### PR TITLE
skipping the prod test for FP8 types in reduce and reduce-scatter

### DIFF
--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -90,7 +90,7 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
-      if((i == ncclFp8E4M3 || i == ncclFp8E5M2) && j == ncclProd)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
         continue;
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }

--- a/src/all_reduce.cu
+++ b/src/all_reduce.cu
@@ -65,8 +65,6 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
-  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
-    return testSuccess;
 
   if ((int)type != -1) {
     type_count = 1;
@@ -90,8 +88,10 @@ testResult_t AllReduceRunTest(struct threadArgs* args, int root, ncclDataType_t 
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
-      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
+#if defined(RCCL_FLOAT8)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && run_ops[j] == ncclProd)
         continue;
+#endif
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }
   }

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -65,6 +65,10 @@ testResult_t ReduceRunTest(struct threadArgs* args, int root, ncclDataType_t typ
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
   int begin_root, end_root;
+  #if defined(RCCL_FLOAT8)
+  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
+    return testSuccess;
+  #endif
 
   if ((int)type != -1) {
     type_count = 1;
@@ -95,6 +99,10 @@ testResult_t ReduceRunTest(struct threadArgs* args, int root, ncclDataType_t typ
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
+#if defined(RCCL_FLOAT8)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
+        continue;
+#endif
       for (int k=begin_root; k<=end_root; k++) {
         TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], k));
       }

--- a/src/reduce.cu
+++ b/src/reduce.cu
@@ -65,10 +65,6 @@ testResult_t ReduceRunTest(struct threadArgs* args, int root, ncclDataType_t typ
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
   int begin_root, end_root;
-  #if defined(RCCL_FLOAT8)
-  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
-    return testSuccess;
-  #endif
 
   if ((int)type != -1) {
     type_count = 1;
@@ -100,7 +96,7 @@ testResult_t ReduceRunTest(struct threadArgs* args, int root, ncclDataType_t typ
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
 #if defined(RCCL_FLOAT8)
-      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && run_ops[j] == ncclProd)
         continue;
 #endif
       for (int k=begin_root; k<=end_root; k++) {

--- a/src/reduce_scatter.cu
+++ b/src/reduce_scatter.cu
@@ -69,6 +69,10 @@ testResult_t ReduceScatterRunTest(struct threadArgs* args, int root, ncclDataTyp
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
+#if defined(RCCL_FLOAT8)
+  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
+    return testSuccess;
+#endif
 
   if ((int)type != -1) {
     type_count = 1;
@@ -92,6 +96,10 @@ testResult_t ReduceScatterRunTest(struct threadArgs* args, int root, ncclDataTyp
 
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
+#if defined(RCCL_FLOAT8)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
+        continue;
+#endif
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));
     }
   }

--- a/src/reduce_scatter.cu
+++ b/src/reduce_scatter.cu
@@ -69,10 +69,6 @@ testResult_t ReduceScatterRunTest(struct threadArgs* args, int root, ncclDataTyp
   ncclRedOp_t *run_ops;
   const char **run_typenames, **run_opnames;
   int type_count, op_count;
-#if defined(RCCL_FLOAT8)
-  if((type == ncclFp8E4M3 || type == ncclFp8E5M2) && op == ncclProd)
-    return testSuccess;
-#endif
 
   if ((int)type != -1) {
     type_count = 1;
@@ -97,7 +93,7 @@ testResult_t ReduceScatterRunTest(struct threadArgs* args, int root, ncclDataTyp
   for (int i=0; i<type_count; i++) {
     for (int j=0; j<op_count; j++) {
 #if defined(RCCL_FLOAT8)
-      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && j == ncclProd)
+      if((run_types[i] == ncclFp8E4M3 || run_types[i] == ncclFp8E5M2) && run_ops[j] == ncclProd)
         continue;
 #endif
       TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], run_ops[j], run_opnames[j], -1));


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._
https://ontrack-internal.amd.com/browse/SWDEV-523031
**What were the changes?**  
Filtering FP8 test cases that use the product operation in reduce and reduce-scatter tests.

**Why were the changes made?**  
rccl does not support FP8 product.

**How was the outcome achieved?**  
Filtering reduce, allreduce, and reduce-scatter test cases when the operation is product on FP8.

**Additional Documentation:**  
_What else should the reviewer know?_
