### PR TITLE
Add instructions to README regarding benchmarking on pre ROCm 6.4.x v…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ Running with 1 MPI process per GPU ensures a 1:1 mapping for CPUs and GPUs, whic
 
 See the [Performance](doc/PERFORMANCE.md) page for explanation about numbers, and in particular the "busbw" column.
 
+### Environment variables
+On some older versions of ROCm before 6.4.0, setting HSA_NO_SCRATCH_RECLAIM=1
+ as part of the environment may be necessary to achieve better performance.  When running without MPI, something like the following is enough:
+```shell
+HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
+```
+
+For MPI, you may need to do something like the following:
+```shell
+mpirun.mpich -np 8 -env NCCL_DEBUG=VERSION -env HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8M -e 128M -i 8388608 -g 1 -d bfloat16
+```
+
 ### Arguments
 
 All tests support the same set of arguments :

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ See the [Performance](doc/PERFORMANCE.md) page for explanation about numbers, an
 
 ### Environment variables
 On some older versions of ROCm before 6.4.0, setting `HSA_NO_SCRATCH_RECLAIM=1`
- as part of the environment may be necessary to achieve better performance.  When running without MPI, something like the following is enough:
+ as part of the environment might be necessary to achieve better performance.  When running without MPI, a command similar to the following one should be sufficient:
 ```shell
 HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Running with 1 MPI process per GPU ensures a 1:1 mapping for CPUs and GPUs, whic
 See the [Performance](doc/PERFORMANCE.md) page for explanation about numbers, and in particular the "busbw" column.
 
 ### Environment variables
-On some older versions of ROCm before 6.4.0, setting HSA_NO_SCRATCH_RECLAIM=1
+On some older versions of ROCm before 6.4.0, setting `HSA_NO_SCRATCH_RECLAIM=1`
  as part of the environment may be necessary to achieve better performance.  When running without MPI, something like the following is enough:
 ```shell
 HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ On some older versions of ROCm before 6.4.0, setting `HSA_NO_SCRATCH_RECLAIM=1`
 HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8 -e 128M -f 2 -g 8
 ```
 
-For MPI, you may need to do something like the following:
+For MPI, you might need to use a command similar to the following:
 ```shell
 mpirun.mpich -np 8 -env NCCL_DEBUG=VERSION -env HSA_NO_SCRATCH_RECLAIM=1 ./build/all_reduce_perf -b 8M -e 128M -i 8388608 -g 1 -d bfloat16
 ```


### PR DESCRIPTION
HSA_NO_SCRATCH_RECLAIM=1instructions

## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Setting HSA_NO_SCRATCH_RECLAIM=1 is necessary to achieve peak performance on ROCm pre 6.4.0.

**Why were the changes made?**  
Make the lives of users of older versions of ROCm easier.

**How was the outcome achieved?**  
N/A

**Additional Documentation:**  
N/A
