### PR TITLE
Fix message size logging

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -760,12 +760,12 @@ testResult_t BenchTime(struct threadArgs* args, ncclDataType_t type, ncclRedOp_t
     PRINT("  %7s  %6.2f  %6.2f  %5s", timeStr, algBw, busBw, "N/A");
   }
 
+  auto largestMessageSize = std::max(args->sendBytes, args->expectedBytes);
   if (args->reporter) {
     if (args->reportErrors) {
-      args->reporter->addResult((args->nThreads * args->nGpus), args->nProcs, args->totalProcs, args->expectedBytes, in_place, timeUsec, algBw, busBw, wrongElts);
-    }
-    else {
-      args->reporter->addResult((args->nThreads * args->nGpus), args->nProcs, args->totalProcs, args->expectedBytes, in_place, timeUsec, algBw, busBw);
+      args->reporter->addResult((args->nThreads * args->nGpus), args->nProcs, args->totalProcs, largestMessageSize, in_place, timeUsec, algBw, busBw, wrongElts);
+    } else {
+      args->reporter->addResult((args->nThreads * args->nGpus), args->nProcs, args->totalProcs, largestMessageSize, in_place, timeUsec, algBw, busBw);
     }
   }
 


### PR DESCRIPTION
Previously, the logger was logging the number of expected bytes a node was to recieve. This differs from the stdout logging, where the reported message size is the total size of a message.

This commit fixes this by ensuring that the json/csv files have the same message size as the rows in stdout

