### PR TITLE
[BUILD] Fix rccl-tests version string for packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,8 @@ set(ROCM_USE_DEV_COMPONENT OFF)  # This repo doesn't have a dev component
 # Add all of the tests
 add_subdirectory(src)
 
+rocm_setup_version(VERSION "2.14.1")
+
 # Create ROCm standard packages
 rocm_create_package(
     NAME rccl-tests


### PR DESCRIPTION
## Details

**Work item:** Internal

**What were the changes?**  
Fixed version string for rccl-tests in `CMakeLists.txt`

**Why were the changes made?**  
Missing version string causes improper nomenclature when packaging rccl-tests.