### PR TITLE
Fix build issues caused by 2.24.3 sync

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @wenkaidu @gilbertlee-amd @akolliasAMD @edgargabriel @PedramAlizadeh @nusislam @nileshnegi @KawtharShafie @AtlantaPepsi @mberenjk @corey-derochie-amd @mustafabar @thananon @JhaShweta1 @haripriya-amd
+* @wenkaidu @gilbertlee-amd @akolliasAMD @edgargabriel @PedramAlizadeh @nusislam @nileshnegi @KawtharShafie @AtlantaPepsi @mberenjk @corey-derochie-amd @mustafabar @thananon @JhaShweta1 @rahulvaidya20 @haripriya-amd
 
 # Documentation files
 doc/ @ROCm/rocm-documentation

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,12 @@
 #include <fstream>
 #include <iostream>
 
+// Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,24,3)
+  #define ncclFp8E4M3 ncclFloat8e4m3
+  #define ncclFp8E5M2 ncclFloat8e5m2
+#endif
+
 // For nccl.h < 2.13 since we define a weak fallback
 extern "C" char const* ncclGetLastError(ncclComm_t comm);
 

--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -23,6 +23,11 @@
 
 #if NCCL_VERSION_CODE >= NCCL_VERSION(2,10,0) && RCCL_FLOAT8 == 1
   #define HAVE_ncclfp8 1
+  // Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
+  #if NCCL_VERSION_CODE >= NCCL_VERSION(2,24,3)
+    #define ncclFp8E4M3 ncclFloat8e4m3
+    #define ncclFp8E5M2 ncclFloat8e5m2
+  #endif
 #else
   #define HAVE_ncclfp8 0
 #endif


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"

**What were the changes?**  
Add aliases for fp8 types for RCCL Versions >= 2.24.3

**Why were the changes made?**  
Recent RCCL sync to 2.24 resulted in changes to fp8 types naming conventions in nccl/types.h. ncclFp8E4M3 and ncclFp8E5M2 were replaced with ncclFloat8e4m3 and ncclFloat8e5m2 respectively. NCCL introduced fp8 datatype support in 2.24.3 - naming conventions in RCCL were updated to ensure compatibility.

**How was the outcome achieved?**  
Checking for RCCL Version in common.h and verifiable.cu and adding fp8 aliases for versions >= 2.24.3. 

**Additional Documentation:**  
typedef cannot be used for creating aliases in this case since datatypes are stored as enum in nccl/types.h and are only used as switch case options in rccl-tests.
