### PR TITLE
Link `Threads::Threads`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,9 +124,6 @@ endif()
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-##Adding pthread flag for linking
-#set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-
 ## Check for HIP
 find_package(hip REQUIRED)
 message(STATUS "HIP compiler:     ${HIP_COMPILER}")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -126,7 +126,7 @@ add_custom_target(git_version_check
 add_custom_target(hipify DEPENDS ${HIP_COMMON_SOURCES})
 add_library(rccl_common OBJECT ${HIP_COMMON_SOURCES})
 add_dependencies(rccl_common hipify git_version_check)
-target_link_libraries(rccl_common roc::rccl hip::device)
+target_link_libraries(rccl_common roc::rccl hip::device Threads::Threads)
 if(USE_MPI)
   target_link_libraries(rccl_common MPI::MPI_CXX)
 endif()


### PR DESCRIPTION
## Details
`pthread.h` is included in `src/common.h` but lib is not properly linked, resulting in the build failing with unresolved symbols when trying to link.

**Work item:**
N/A

**What were the changes?**  
`Threads::Threads` is linked where appropriate.

**Why were the changes made?**  
Building rccl-tests with [TheRock](https://github.com/ROCm/TheRock) in a manylinux Docker container fails with
```[rccl-tests] [27/47] Linking CXX executable reduce_perf
[rccl-tests] FAILED: reduce_perf 
[rccl-tests] : && /therock/build-docker/core/clr/dist/lib/llvm/bin/clang++ -Wno-documentation-unknown-command -Wno-documentation-pedantic -Wno-unused-command-line-argument --hip-path=/therock/build-docker/core/clr/dist --hip-device-lib-path=/therock/build-docker/core/clr/dist/lib/llvm/amdgcn/bitcode -O3 -DNDEBUG -L /therock/build-docker/third-party/sysdeps/linux/zlib/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/zlib/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/third-party/sysdeps/linux/zstd/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/zstd/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/compiler/amd-llvm/stage/lib/llvm/lib -Wl,-rpath-link,/therock/build-docker/compiler/amd-llvm/stage/lib/llvm/lib -L /therock/build-docker/base/rocprofiler-register/stage/lib -Wl,-rpath-link,/therock/build-docker/base/rocprofiler-register/stage/lib -L /therock/build-docker/third-party/sysdeps/linux/bzip2/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/bzip2/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/third-party/sysdeps/linux/elfutils/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/elfutils/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/third-party/sysdeps/linux/libdrm/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/libdrm/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/third-party/sysdeps/linux/numactl/build/stage/lib/rocm_sysdeps/lib -Wl,-rpath-link,/therock/build-docker/third-party/sysdeps/linux/numactl/build/stage/lib/rocm_sysdeps/lib -L /therock/build-docker/core/ROCR-Runtime/stage/lib -Wl,-rpath-link,/therock/build-docker/core/ROCR-Runtime/stage/lib -L /therock/build-docker/core/clr/stage/lib -Wl,-rpath-link,/therock/build-docker/core/clr/stage/lib -L /therock/build-docker/base/rocm_smi_lib/stage/lib -Wl,-rpath-link,/therock/build-docker/base/rocm_smi_lib/stage/lib src/CMakeFiles/rccl_common.dir/hipify/common.cu.cpp.o src/CMakeFiles/rccl_common.dir/hipify/timer.cc.o src/CMakeFiles/rccl_common.dir/hipify/verifiable.cu.cpp.o src/CMakeFiles/rccl_common.dir/git_version.cpp.o src/CMakeFiles/reduce_perf.dir/hipify/reduce.cu.cpp.o -o reduce_perf  -Wl,-rpath,/therock/build-docker/comm-libs/rccl/dist/lib:/therock/build-docker/core/clr/dist/lib:  /therock/build-docker/comm-libs/rccl/dist/lib/librccl.so.1.0  /therock/build-docker/core/clr/dist/lib/libamdhip64.so.6.5.25172-a9b10910c  --hip-link  --offload-arch=gfx1100  --offload-arch=gfx1101  --offload-arch=gfx1102  /therock/build-docker/core/clr/dist/lib/llvm/lib/clang/19/lib/linux/libclang_rt.builtins-x86_64.a && :
[rccl-tests] ld.lld: error: undefined symbol: pthread_create
[rccl-tests] >>> referenced by common.cu.cpp
[rccl-tests] >>>               src/CMakeFiles/rccl_common.dir/hipify/common.cu.cpp.o:(threadLaunch(testThread*))
[rccl-tests] >>> referenced by common.cu.cpp
[rccl-tests] >>>               src/CMakeFiles/rccl_common.dir/hipify/common.cu.cpp.o:(run())
[rccl-tests] 
[rccl-tests] ld.lld: error: undefined symbol: pthread_join
[rccl-tests] >>> referenced by common.cu.cpp
[rccl-tests] >>>               src/CMakeFiles/rccl_common.dir/hipify/common.cu.cpp.o:(run())
```

**How was the outcome achieved?**  
N/A

**Additional Documentation:**  
N/A
