### PR TITLE
Ensure backward compatibility for fp8 datatypes

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -22,7 +22,7 @@
 #include <fstream>
 #include <iostream>
 
-// Ensures backward compatibility for FP8 types
+// Ensures backward compatibility for FP8 datatypes
 #if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
   #define ncclFloat8e4m3 ncclFp8E4M3
   #define ncclFloat8e5m2 ncclFp8E5M2

--- a/src/common.h
+++ b/src/common.h
@@ -22,10 +22,10 @@
 #include <fstream>
 #include <iostream>
 
-// Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,24,3)
-  #define ncclFp8E4M3 ncclFloat8e4m3
-  #define ncclFp8E5M2 ncclFloat8e5m2
+// Ensures backward compatibility for FP8 types
+#if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
+  #define ncclFloat8e4m3 ncclFp8E4M3
+  #define ncclFloat8e5m2 ncclFp8E5M2
 #endif
 
 // For nccl.h < 2.13 since we define a weak fallback

--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -28,9 +28,9 @@
   #define HAVE_ncclfp8_HOST 1
 #endif
 // Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
-#if NCCL_VERSION_CODE >= NCCL_VERSION(2,24,3)
-  #define ncclFp8E4M3 ncclFloat8e4m3
-  #define ncclFp8E5M2 ncclFloat8e5m2
+#if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
+  #define ncclFloat8e4m3 ncclFp8E4M3
+  #define ncclFloat8e5m2 ncclFp8E5M2
 #endif
 #else
   #define HAVE_ncclfp8 0

--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -27,7 +27,7 @@
 #else
   #define HAVE_ncclfp8_HOST 1
 #endif
-// Ensures backward compatibility for FP8 types in RCCL 2.24.3 and later
+// Ensures backward compatibility for FP8 datatypes
 #if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
   #define ncclFloat8e4m3 ncclFp8E4M3
   #define ncclFloat8e5m2 ncclFp8E5M2


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal"

**What were the changes?**  
Change fp8 aliases to support new rccl-tests changes

**Why were the changes made?**  
To ensure backward compatibility for building rccl-tests with older rccl versions.

**How was the outcome achieved?**  
By ensuring that rccl-tests can be built using older rccl versions. Added aliases to support older fp8 datatypes for rccl versions < 2.24.3

**Additional Documentation:**  
_What else should the reviewer know?_
