### PR TITLE
Add cstring header explictly as it is removed from HIP

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -11,6 +11,7 @@
 #include "rccl/rccl.h"
 #include <stdio.h>
 #include <cstdint>
+#include <cstring>
 #include <algorithm>
 #ifdef MPI_SUPPORT
 #include "mpi.h"


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Add < cstring > header to fix the below errors such as "./common.h:202:10: error: use of undeclared identifier 'strncpy'"

**Why were the changes made?**  
As part of 7.0 breaking changes, HIP runtime header files (hip_runtime.h) stopped including headers such as < cstring > or < string.h > since they were not used in hip runtime. But the apps depending on that header file will fail with the errors and those need to add the header explicitly.

**How was the outcome achieved?**  
By adding < cstring > header.

