### PR TITLE
Fix buffer registration by correctly passing ncclCommRegister args

### DIFF
--- a/src/common.cu
+++ b/src/common.cu
@@ -1507,8 +1507,8 @@ testResult_t run() {
      sendRegHandles = (local_register) ? (void **)malloc(sizeof(*sendRegHandles)*nThreads*nGpus) : NULL;
      recvRegHandles = (local_register) ? (void **)malloc(sizeof(*recvRegHandles)*nThreads*nGpus) : NULL;
      for (int i=0; i<nGpus*nThreads; i++) {
-       if (local_register) NCCLCHECK(ncclCommRegister(comms[i], &sendbuffs[i], maxBytes, &sendRegHandles[i]));
-       if (local_register) NCCLCHECK(ncclCommRegister(comms[i], &recvbuffs[i], maxBytes, &recvRegHandles[i]));
+       if (local_register) NCCLCHECK(ncclCommRegister(comms[i], sendbuffs[i], maxBytes, &sendRegHandles[i]));
+       if (local_register) NCCLCHECK(ncclCommRegister(comms[i], recvbuffs[i], maxBytes, &recvRegHandles[i]));
      }
 #endif
   }


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** LWPCOMMLIBS-658

**What were the changes?**  
Fixed buffer registration in RCCL tests by correctly passing device buffer pointers to ncclCommRegister.

**Why were the changes made?**  
When using the -R flag for local buffer registration, the non-parallel initialization path was incorrectly passing pointer addresses (&sendbuffs[i]) instead of the actual device buffer pointers (sendbuffs[i]), causing registration failures

**How was the outcome achieved?**  
By passing the actual device buffers instead of a pointer to the device buffer.

**Additional Documentation:**  

