### PR TITLE
Standardize output formats

### DIFF
--- a/src/alltoallv.cu
+++ b/src/alltoallv.cu
@@ -181,7 +181,7 @@ testResult_t AlltoAllvRunTest(struct threadArgs* args, int root, ncclDataType_t 
   }
 
   for (int i=0; i<type_count; i++) {
-      TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], (ncclRedOp_t)0, "", -1));
+      TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], (ncclRedOp_t)0, "none", -1));
   }
   return testSuccess;
 }

--- a/src/common.cu
+++ b/src/common.cu
@@ -131,14 +131,14 @@ Reporter::Reporter(std::string fileName, std::string outputFormat) : _outputForm
       _out = std::ofstream(fileName, std::ios_base::out);
       _outputValid = true;
       if (_outputFormat == "csv") {
-        _out << "numCycle, ";
-        _out << "collective, ";
+        _out << "numCycle,";
+        _out << "collective,";
 #ifdef MPI_SUPPORT
-        _out << "ranks, rankspernode, gpusperrank, ";
+        _out << "ranks,rankspernode,gpusperrank,";
 #else
-        _out << "gpus, ";
+        _out << "gpus,";
 #endif
-        _out << "size, type, redop, inplace, time, algbw, busbw, #wrong\n";
+        _out << "size,type,redop,inplace,time,algbw,busbw,#wrong\n";
       }
     }
   }
@@ -185,7 +185,7 @@ void Reporter::addResult(int gpusPerRank, int ranksPerNode, int totalRanks, size
     if (_outputFormat == "csv") {
       _out << iter->first;
       if (std::next(iter) != outputValuesKeys.end()) {
-        _out << ", ";
+        _out << ",";
       }
     } else { //json
       if (iter == outputValuesKeys.begin()) {

--- a/src/common.cu
+++ b/src/common.cu
@@ -130,16 +130,6 @@ Reporter::Reporter(std::string fileName, std::string outputFormat) : _outputForm
     if (isMainThread()) {
       _out = std::ofstream(fileName, std::ios_base::out);
       _outputValid = true;
-      if (_outputFormat == "csv") {
-        _out << "numCycle,";
-        _out << "collective,";
-#ifdef MPI_SUPPORT
-        _out << "ranks,rankspernode,gpusperrank,";
-#else
-        _out << "gpus,";
-#endif
-        _out << "size,type,redop,inplace,time,algbw,busbw,#wrong\n";
-      }
     }
   }
 }
@@ -181,26 +171,53 @@ void Reporter::addResult(int gpusPerRank, int ranksPerNode, int totalRanks, size
   outputValuesKeys.push_back(makeValueKeyPair(busBw, "busBw"));
   outputValuesKeys.push_back(makeValueKeyPair(wrongEltsStr, "wrong"));
 
-  for (auto iter = outputValuesKeys.begin(); iter != outputValuesKeys.end(); ++iter) {
-    if (_outputFormat == "csv") {
-      _out << iter->first;
-      if (std::next(iter) != outputValuesKeys.end()) {
-        _out << ",";
+  _outputData.push_back(outputValuesKeys);
+}
+
+void Reporter::writeFile() {
+  if (!isMainThread() || !_outputValid)
+    return;
+
+  if (_outputFormat == "csv") {
+    _out << "numCycle,";
+    _out << "collective,";
+#ifdef MPI_SUPPORT
+    _out << "ranks,rankspernode,gpusperrank,";
+#else
+    _out << "gpus,";
+#endif
+    _out << "size,type,redop,inplace,time,algbw,busbw,#wrong\n";
+    for (auto iterEntries = _outputData.begin(); iterEntries != _outputData.end(); ++iterEntries) {
+      for (auto iterVals = (*iterEntries).begin(); iterVals != (*iterEntries).end(); ++iterVals) {
+	_out << iterVals->first;
+	if (std::next(iterVals) != (*iterEntries).end()) {
+	  _out << ",";
+	}
       }
-    } else { //json
-      if (iter == outputValuesKeys.begin()) {
-        _out << "{";
+      _out << std::endl;
+    }
+  } else { //json
+    _out << "[" << std::endl;
+    for (auto iterEntries = _outputData.begin(); iterEntries != _outputData.end(); ++iterEntries) {
+      for (auto iterVals = (*iterEntries).begin(); iterVals != (*iterEntries).end(); ++iterVals) {
+        if (iterVals == (*iterEntries).begin()) {
+          _out << "{";
+        }
+        _out << "\"" << iterVals->second << "\":" << iterVals->first;
+        if (std::next(iterVals) != (*iterEntries).end()) {
+          _out << ", ";
+	}
       }
-      _out << "\"" << iter->second << "\":" << iter->first;
-      if (std::next(iter) != outputValuesKeys.end()) {
-        _out << ", ";
+      if (std::next(iterEntries) != _outputData.end()) {
+        _out << "}," << std::endl;
       } else {
-        _out << "}";
+	_out << "}" << std::endl;
       }
     }
+    _out << "]" << std::endl;
   }
-  _out << std::endl;
 }
+
 
 bool Reporter::isMainThread() { return is_main_thread == 1; }
 static int minCudaArch = 1<<30;
@@ -1639,6 +1656,8 @@ testResult_t run() {
   MPI_Comm_free(&mpi_comm);
   MPI_Finalize();
 #endif
+
+  reporter.writeFile();
 
   // 'cuda-memcheck --leak-check full' requires this
   PRINT("%s\n", ncclGetLastError(NULL));

--- a/src/common.h
+++ b/src/common.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <fstream>
 #include <iostream>
+#include <utility>
+#include <vector>
 
 // Ensures backward compatibility for FP8 datatypes
 #if NCCL_VERSION_CODE < NCCL_VERSION(2,24,3)
@@ -119,6 +121,7 @@ class Reporter {
     ~Reporter() { if (_outputValid) { _out.close(); } };
     void setParameters(const size_t numCycle, const char* name, const char* typeName, const char* opName);
     void addResult(int gpusPerRank, int ranksPerNode, int totalRanks, size_t numBytes, int inPlace, double timeUsec, double algBw, double busBw, int64_t wrongElts = -1);
+    void writeFile();
 
   private:
     bool isMainThread();
@@ -132,6 +135,7 @@ class Reporter {
     std::string _collectiveName;
     std::string _typeName;
     std::string _opName;
+    std::vector<std::vector<std::pair<std::string, std::string>>> _outputData;
 };
 
 struct testEngine {

--- a/src/hypercube.cu
+++ b/src/hypercube.cu
@@ -101,7 +101,7 @@ testResult_t HyperCubeRunTest(struct threadArgs* args, int root, ncclDataType_t 
   int nRanks = args->nProcs*args->nThreads*args->nGpus;
   if (nRanks && !(nRanks & (nRanks - 1))) {
     for (int i=0; i<type_count; i++) {
-      TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], (ncclRedOp_t)0, "", -1));
+      TESTCHECK(TimeTest(args, run_types[i], run_typenames[i], (ncclRedOp_t)0, "none", -1));
     }
   } else {
     printf("nRanks %d is not a power of 2, skipping\n", nRanks);


### PR DESCRIPTION
## Details
**Work item:** Internal

**What were the changes?**  
The formatting for the optional CSV and JSON output files was updated to use standard separators. (e.g. removing spaces between items in the CSV, adding commas between JSON fragments)

**Why were the changes made?**  
The current CSV output files were not working properly when imported into other applications. For example, when imported into Excel, the quotes around strings are not removed due to leading spaces. The JSON output could not easily be dumped to a Python dictionary because the file consisted of JSON fragments rather than a valid JSON list. These changes improve usability for performance testing and analysis that use rccl-tests.

**How was the outcome achieved?**  
Instead of writing each result to the file individually, the results were stored until the end of the test, at which point all results can be written to the file with the desired formatting.
