### PR TITLE
Dependency removal with hipify_perl symlink

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,7 +21,7 @@ function(add_rccl_test TEST)
     # Create a custom command to create hipified source code
     add_custom_command(
         OUTPUT ${HIP_FILE}
-        COMMAND mkdir -p ${HIP_FILE_DIR} && $ ${hipify-perl_executable} -quiet-warnings ${SOURCE_DIR}/${TEST_SOURCE} -o ${HIP_FILE}
+        COMMAND mkdir -p ${HIP_FILE_DIR} && $ ${hipify-perl_executable} ${HIPIFY_PL_FLAGS} ${SOURCE_DIR}/${TEST_SOURCE} -o ${HIP_FILE}
         MAIN_DEPENDENCY ${TEST_SOURCE}
         COMMENT "Hipifying ${TEST_SOURCE} -> ${HIP_FILE}"
     )
@@ -82,6 +82,15 @@ set(COMMON_FILES
 # Hipify common files (copy of source generated into hipify directory)
 #==================================================================================================
 find_program(hipify-perl_executable hipify-perl)
+if(hipify-perl_executable)
+  set(HIPIFY_PL_FLAGS "-quiet-warnings")
+else()
+  find_program(hipify-perl_executable hipify-clang)
+  if(hipify-perl_executable)
+    message(STATUS "hipify-perl is not found/deprecated using hipify-clang")
+  endif()
+  set(HIPIFY_PL_FLAGS "")
+endif()
 set(HIPIFY_DIR "${CMAKE_CURRENT_BINARY_DIR}/hipify")
 set(SOURCE_DIR "${CMAKE_SOURCE_DIR}/src")
 
@@ -103,7 +112,7 @@ foreach(COMMON_FILE ${COMMON_FILES})
   # Create a custom command to create hipified source code
   add_custom_command(
     OUTPUT ${HIP_FILE}
-    COMMAND mkdir -p ${HIPIFY_DIR} && $ ${hipify-perl_executable} -quiet-warnings ${SOURCE_DIR}/${COMMON_FILE} -o ${HIP_FILE}
+    COMMAND mkdir -p ${HIPIFY_DIR} && $ ${hipify-perl_executable} ${HIPIFY_PL_FLAGS} ${SOURCE_DIR}/${COMMON_FILE} -o ${HIP_FILE}
     MAIN_DEPENDENCY ${COMMON_FILE}
     COMMENT "Hipifying ${COMMON_FILE} -> ${HIP_FILE}"
   )

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,8 @@ CUSTOM_RCCL_LIB ?= ""
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 HIPCONFIG = $(ROCM_PATH)/bin/hipconfig
+HIPIFY_PL = $(ROCM_PATH)/bin/hipify-perl
+HIPIFY_PL_FLAGS = -quiet-warnings
 CXX = $(HIPCC)
 
 HIPCUFLAGS := -std=c++14
@@ -32,6 +34,12 @@ DSO ?= 0
 HIP_VERSION = $(strip $(shell which $(HIPCONFIG) >/dev/null && $(HIPCONFIG) --version))
 HIP_MAJOR = $(shell echo $(HIP_VERSION) | cut -d "." -f 1)
 HIP_MINOR = $(shell echo $(HIP_VERSION) | cut -d "." -f 2)
+
+# TODO: Check HIPIFY_PL deprecated and use hipify-clang
+#  HIPIFY_PL = $(ROCM_PATH)/bin/hipify-clang
+#  HIPIFY_PL_FLAGS = ""
+#  $(shell echo "hipify-perl is not found/deprecated using hipify-clang.")
+#fi
 
 # Better define GPU_TARGETS in your environment to the minimal set
 # of archs to reduce compile time.
@@ -158,12 +166,12 @@ $(GIT_VERSION_FILE):
 ${HIPIFY_DIR}/%.cu.cpp: %.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/%.h: %.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
 
 .PRECIOUS: ${DST_DIR}/%.o
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -16,9 +16,14 @@ CUSTOM_RCCL_LIB ?= ""
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 HIPCONFIG = $(ROCM_PATH)/bin/hipconfig
-HIPIFY_PL = $(ROCM_PATH)/bin/hipify-perl
-HIPIFY_PL_FLAGS = -quiet-warnings
 CXX = $(HIPCC)
+# HIPIFY PL Deprecation Handling
+HIPIFY_PL_EXE=$(ROCM_PATH)/bin/hipify-perl
+HIPIFY_CL_EXE=$(ROCM_PATH)/bin/hipify-clang
+HIPIFY_PL_FLAGS = -quiet-warnings
+HIPIFY_CL_FLAGS = ""
+HIPIFY_EXE = $(shell if [ -f $(HIPIFY_PL_EXE) ];then echo "$(HIPIFY_PL_EXE)"; else echo "$(HIPIFY_CL_EXE)";fi)
+HIPIFY_EXE_FLAGS = $(shell if [ -f $(HIPIFY_PL_EXE) ];then echo "$(HIPIFY_PL_FLAGS)"; else echo "$(HIPIFY_CL_FLAGS)";fi)
 
 HIPCUFLAGS := -std=c++14
 LDFLAGS    :=
@@ -35,11 +40,6 @@ HIP_VERSION = $(strip $(shell which $(HIPCONFIG) >/dev/null && $(HIPCONFIG) --ve
 HIP_MAJOR = $(shell echo $(HIP_VERSION) | cut -d "." -f 1)
 HIP_MINOR = $(shell echo $(HIP_VERSION) | cut -d "." -f 2)
 
-# TODO: Check HIPIFY_PL deprecated and use hipify-clang
-#  HIPIFY_PL = $(ROCM_PATH)/bin/hipify-clang
-#  HIPIFY_PL_FLAGS = ""
-#  $(shell echo "hipify-perl is not found/deprecated using hipify-clang.")
-#fi
 
 # Better define GPU_TARGETS in your environment to the minimal set
 # of archs to reduce compile time.
@@ -166,12 +166,12 @@ $(GIT_VERSION_FILE):
 ${HIPIFY_DIR}/%.cu.cpp: %.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
+	${HIPIFY_EXE} ${HIPIFY_EXE_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/%.h: %.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
+	${HIPIFY_EXE} ${HIPIFY_EXE_FLAGS} $< > $@
 
 .PRECIOUS: ${DST_DIR}/%.o
 

--- a/verifiable/verifiable.mk
+++ b/verifiable/verifiable.mk
@@ -15,17 +15,17 @@ TEST_VERIFIABLE_LIBS      = $(TEST_VERIFIABLE_BUILDDIR)/libverifiable.so
 ${HIPIFY_DIR}/verifiable.cu.cpp: $(TEST_VERIFIABLE_SRCDIR)/verifiable.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
+	${HIPIFY_EXE} ${HIPIFY_EXE_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/verifiable.h: $(TEST_VERIFIABLE_SRCDIR)/verifiable.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
+	${HIPIFY_EXE} ${HIPIFY_EXE_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/rccl_float8.h: $(TEST_VERIFIABLE_SRCDIR)/../src/rccl_float8.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
+	${HIPIFY_EXE} ${HIPIFY_EXE_FLAGS} $< > $@
 
 $(TEST_VERIFIABLE_BUILDDIR)/verifiable.o: $(HIPIFY_DIR)/verifiable.cu.cpp $(HIPIFY_DIR)/verifiable.h $(HIPIFY_DIR)/rccl_float8.h
 	@printf "Compiling %s\n" $@

--- a/verifiable/verifiable.mk
+++ b/verifiable/verifiable.mk
@@ -15,17 +15,17 @@ TEST_VERIFIABLE_LIBS      = $(TEST_VERIFIABLE_BUILDDIR)/libverifiable.so
 ${HIPIFY_DIR}/verifiable.cu.cpp: $(TEST_VERIFIABLE_SRCDIR)/verifiable.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/verifiable.h: $(TEST_VERIFIABLE_SRCDIR)/verifiable.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/rccl_float8.h: $(TEST_VERIFIABLE_SRCDIR)/../src/rccl_float8.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL} ${HIPIFY_PL_FLAGS} $< > $@
 
 $(TEST_VERIFIABLE_BUILDDIR)/verifiable.o: $(HIPIFY_DIR)/verifiable.cu.cpp $(HIPIFY_DIR)/verifiable.h $(HIPIFY_DIR)/rccl_float8.h
 	@printf "Compiling %s\n" $@


### PR DESCRIPTION
## Details
Removing Dependency with hipify-perl symlink usage from rccl-test
Handle future changes of hipify-perl

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
1. Invocation of hipify-perl symlink moved to invocation using absolute file path
2. Gracefully handle non availability of hipify-perl
This pull request updates both the CMake and Makefile build systems to better handle the deprecation of `hipify-perl` by supporting both `hipify-perl` and its replacement, `hipify-clang`. The logic now automatically detects which hipify tool is available and sets the appropriate flags, improving compatibility and future-proofing the build process.

**Why were the changes made?**  
1. To fix build issues due to usage of hipify-perl symlink, which are deprecated.
2. To handle future deprecation of hipify-perl

**How was the outcome achieved?**  
* Added logic in `src/CMakeLists.txt` to detect whether `hipify-perl` or `hipify-clang` is available, set the appropriate executable and flags (`-quiet-warnings` for `hipify-perl`, none for `hipify-clang`), and updated all hipify commands to use these variables. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R85-R93) [[2]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L24-R24) [[3]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L106-R115)
* Updated `src/Makefile` to define variables for both hipify tools, automatically select the available one, and set the correct flags for each; all hipify invocations now use these variables. [[1]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685R20-R26) [[2]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L161-R174)
* Applied the same hipify tool selection and flag logic to `verifiable/verifiable.mk` for consistency in the verifiable tests build.


**Additional Documentation:**  
_What else should the reviewer know?_
