### PR TITLE
Dependency removal with hipify_perl symlink

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,6 +16,8 @@ CUSTOM_RCCL_LIB ?= ""
 
 HIPCC ?= $(ROCM_PATH)/bin/amdclang++
 HIPCONFIG = $(ROCM_PATH)/bin/hipconfig
+HIPIFY_PL_EXE=$(ROCM_PATH)/bin/hipify-perl
+HIPIFY_PL_FLAGS = -quiet-warnings
 CXX = $(HIPCC)
 
 HIPCUFLAGS := -std=c++14
@@ -158,12 +160,12 @@ $(GIT_VERSION_FILE):
 ${HIPIFY_DIR}/%.cu.cpp: %.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL_EXE} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/%.h: %.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL_EXE} ${HIPIFY_PL_FLAGS} $< > $@
 
 .PRECIOUS: ${DST_DIR}/%.o
 

--- a/verifiable/verifiable.mk
+++ b/verifiable/verifiable.mk
@@ -15,17 +15,17 @@ TEST_VERIFIABLE_LIBS      = $(TEST_VERIFIABLE_BUILDDIR)/libverifiable.so
 ${HIPIFY_DIR}/verifiable.cu.cpp: $(TEST_VERIFIABLE_SRCDIR)/verifiable.cu
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL_EXE} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/verifiable.h: $(TEST_VERIFIABLE_SRCDIR)/verifiable.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL_EXE} ${HIPIFY_PL_FLAGS} $< > $@
 
 ${HIPIFY_DIR}/rccl_float8.h: $(TEST_VERIFIABLE_SRCDIR)/../src/rccl_float8.h
 	@printf "Hipifying  %-35s > %s\n" $< $@
 	@mkdir -p ${HIPIFY_DIR}
-	hipify-perl -quiet-warnings $< > $@
+	${HIPIFY_PL_EXE} ${HIPIFY_PL_FLAGS} $< > $@
 
 $(TEST_VERIFIABLE_BUILDDIR)/verifiable.o: $(HIPIFY_DIR)/verifiable.cu.cpp $(HIPIFY_DIR)/verifiable.h $(HIPIFY_DIR)/rccl_float8.h
 	@printf "Compiling %s\n" $@


### PR DESCRIPTION
## Details
Removing Dependency with hipify-perl symlink usage from rccl-test

**Work item:** _"Internal", or link to GitHub issue (if applicable)._

**What were the changes?**  
Invocation of hipify-perl symlink moved to invocation using absolute file path
This pull request updates the way the `hipify-perl` tool is invoked in the build system to improve maintainability and configurability. Instead of calling `hipify-perl` directly with hardcoded flags, the Makefiles now use variables for the executable path and flags, making it easier to change these settings in one place if needed.


**Why were the changes made?**  
To fix build issues due to usage of hipify-perl symlink, which are deprecated.

**How was the outcome achieved?**  
* Introduced `HIPIFY_PL_EXE` and `HIPIFY_PL_FLAGS` variables in `src/Makefile` to define the path to the `hipify-perl` executable and its flags, centralizing configuration.
* Updated all invocations of `hipify-perl` in both `src/Makefile` and `verifiable/verifiable.mk` to use the new variables, replacing hardcoded calls and flags. [[1]](diffhunk://#diff-3e2513390df543315686d7c85bd901ca9256268970032298815d2f893a9f0685L161-R168) [[2]](diffhunk://#diff-11f2f5c19a3d18b9127f48a5ef06d0b3b0d7f383ca353f3af15da7d6e42545abL18-R28)

**Additional Documentation:**  
_What else should the reviewer know?_
