### PR TITLE
[BUILD] Add rccl_compat.h to src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set(COMMON_FILES
   common.h
   common.cu
   nccl1_compat.h
+  rccl_compat.h
   rccl_float8.h
   timer.h
   timer.cc


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Fix CMake builds for rccl-tests

**Why were the changes made?**  
CMake-based build was failing, as PR https://github.com/ROCm/rccl-tests/pull/151 introduced a new file `src/rccl_compat.h`.

**How was the outcome achieved?**  
Add `rccl_compat.h` to the common files list in `src/CMakeLists.txt`
