### PR TITLE
[BUILD] Add link to `libdl` for RCCL-Tests builds

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,7 +127,7 @@ add_custom_target(git_version_check
 add_custom_target(hipify DEPENDS ${HIP_COMMON_SOURCES})
 add_library(rccl_common OBJECT ${HIP_COMMON_SOURCES})
 add_dependencies(rccl_common hipify git_version_check)
-target_link_libraries(rccl_common roc::rccl hip::device Threads::Threads)
+target_link_libraries(rccl_common roc::rccl hip::device Threads::Threads dl)
 if(USE_MPI)
   target_link_libraries(rccl_common MPI::MPI_CXX)
 endif()

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 #
 # See LICENSE.txt for license information
 #
-#include common.mk
+include common.mk
 
 ROCM_PATH ?= /opt/rocm
 MPI_HOME ?= /usr/lib/x86_64-linux-gnu

--- a/src/Makefile
+++ b/src/Makefile
@@ -4,7 +4,7 @@
 #
 # See LICENSE.txt for license information
 #
-include common.mk
+#include common.mk
 
 ROCM_PATH ?= /opt/rocm
 MPI_HOME ?= /usr/lib/x86_64-linux-gnu
@@ -129,7 +129,7 @@ HIPCUFLAGS += -DMPI_SUPPORT -I${MPI_HOME}/include -I${MPI_HOME}/mpich/include -I
 HIPLDFLAGS += -L${MPI_HOME}/lib -L${MPI_HOME}/mpich/lib -lmpich
 endif
 
-LIBRARIES += rccl
+LIBRARIES += rccl dl
 HIPLDFLAGS += $(LIBRARIES:%=-l%)
 
 DST_DIR := $(BUILDDIR)


### PR DESCRIPTION
## Details

**Work item:**
Internal

**What were the changes?**  
Add link to `libdl` in RCCL-Tests CMake and Makefile builds.

**Why were the changes made?**  
RCCL-Tests builds on TheRock were failing due to the dependency on `libdl` as a result of the newly added function `loadRcclSyms()` https://github.com/ROCm/rccl-tests/commit/0c94d4d2b3fda463ec30d2b469ae25375dbad2a8#diff-213de7a2fa0f343bb516d575946d5ab3675c03f4be0b493607f08ad7bf71d0d5R41