### PR TITLE
Fixing the AR_Bias issue for FP8

### DIFF
--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -1084,8 +1084,8 @@ void applyBias1(
   case ncclBfloat16: CASE_TY(hip_bfloat16)
   #endif
   #if HAVE_ncclfp8_DEVICE || HIP_VERSION < 60300000
-  case ncclFp8E4M3: CASE_TY(rccl_float8)
-  case ncclFp8E5M2: CASE_TY(rccl_bfloat8)
+  case ncclFloat8e4m3: CASE_TY(rccl_float8)
+  case ncclFloat8e5m2: CASE_TY(rccl_bfloat8)
   #elif HAVE_ncclfp8_HOST
   case ncclFloat8e4m3: if (rccl_float8_useFnuz) { CASE_TY(__hip_fp8_e4m3_fnuz) }
   else { CASE_TY(__hip_fp8_e4m3) }

--- a/verifiable/verifiable.cu
+++ b/verifiable/verifiable.cu
@@ -1083,9 +1083,14 @@ void applyBias1(
   #if HAVE_ncclBfloat16
   case ncclBfloat16: CASE_TY(hip_bfloat16)
   #endif
-  #if HAVE_ncclfp8
+  #if HAVE_ncclfp8_DEVICE || HIP_VERSION < 60300000
   case ncclFp8E4M3: CASE_TY(rccl_float8)
   case ncclFp8E5M2: CASE_TY(rccl_bfloat8)
+  #elif HAVE_ncclfp8_HOST
+  case ncclFloat8e4m3: if (rccl_float8_useFnuz) { CASE_TY(__hip_fp8_e4m3_fnuz) }
+  else { CASE_TY(__hip_fp8_e4m3) }
+  case ncclFloat8e5m2: if (rccl_float8_useFnuz) { CASE_TY(__hip_fp8_e5m2_fnuz) }
+  else { CASE_TY(__hip_fp8_e5m2) }
   #endif
   case ncclFloat32: CASE_TY(float)
   case ncclFloat64: CASE_TY(double)


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:[SWDEV-559820]

**What were the changes?**  
 AR_With_Bias needs to support both fp8 types on host and device.

**Why were the changes made?**  
There was a crash occurred when using fp8.

**How was the outcome achieved?**  


**Additional Documentation:**  

