### PR TITLE
Update AlltoAll and AlltoAllv API for 2.28.3 compatibility

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -30,6 +30,12 @@
   #define ncclFloat8e5m2 ncclFp8E5M2
 #endif
 
+// Forward compatibility for AlltoAll API changes in 2.28.3
+#if NCCL_VERSION_CODE >= NCCL_VERSION(2,28,3)
+  #define ncclAllToAll ncclAlltoAll
+  #define ncclAllToAllv ncclAlltoAllv
+#endif
+
 // For nccl.h < 2.13 since we define a weak fallback
 extern "C" char const* ncclGetLastError(ncclComm_t comm);
 


### PR DESCRIPTION
## Details
___Do not mention proprietary info or link to internal work items in this PR.___

**Work item:** Internal

**What were the changes?**  
Update AlltoAll and AlltoAllv API calls to maintain compatibility with RCCL 2.28.3.

**Why were the changes made?**  
To ensure compatibility with RCCL versions greater than 2.28.3.

**How was the outcome achieved?**  
By updating the API calls appropriately using the RCCL version check.

**Additional Documentation:**  
_What else should the reviewer know?_
